### PR TITLE
subjectaltname should return Array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - '4'
 install:
   - npm install -g npm
+  - npm install
 cache:
   directories:
     - node_modules

--- a/index.js
+++ b/index.js
@@ -95,10 +95,13 @@ function geneerateStateResponse(res) {
 }
 
 function generateTlsResponse(res) {
+  const sans = res.subjectaltname.split(',')
+                                  .map(v => v.replace(/DNS\:/, ''))
+                                  .filter(v => v !== '')
   return {
     subject: res.subject,
     issuer: res.issuer,
-    subjectaltname: res.subjectaltname,
+    subjectaltname: sans,
     valid_from: res.valid_from,
     valid_to: res.valid_to,
     infoAccess: res.infoAccess,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-data",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "simple page data get client tool",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ test('.tls() is return tls status', t => {
     t.not(res.infoAccess, null);
     t.is(typeof(res.infoAccess), 'object');
     t.not(res.subjectaltname, null);
-    t.is(typeof(res.subjectaltname), 'string');
+    t.is(typeof(res.subjectaltname), 'object');
     t.not(res.serialNumber, null);
     t.is(typeof(res.serialNumber), 'string');
   });
@@ -71,7 +71,7 @@ test.cb('.tls() with callback is return tls status', t => {
           t.not(res.infoAccess, null);
           t.is(typeof(res.infoAccess), 'object');
           t.not(res.subjectaltname, null);
-          t.is(typeof(res.subjectaltname), 'string');
+          t.is(typeof(res.subjectaltname), 'object');
           t.not(res.serialNumber, null);
           t.is(typeof(res.serialNumber), 'string');
           t.end();


### PR DESCRIPTION
### Summary

Changed `subjectaltname` to return Array instead of string.
It is better for you to make it easier to use on the client side.

### Other Information

## current

```js
{ subject: { CN: 'kazu69.xyz' },
  issuer:
   { C: 'US',
     O: 'Let\'s Encrypt',
     CN: 'Let\'s Encrypt Authority X3' },
  subjectaltname: 'DNS:kazu69.xyz, DNS:www.kazu69.xyz',
  valid_from: 'Jul 13 23:42:00 2017 GMT',
  valid_to: 'Oct 11 23:42:00 2017 GMT',
  infoAccess:
   { 'OCSP - URI': [ 'http://ocsp.int-x3.letsencrypt.org' ],
     'CA Issuers - URI': [ 'http://cert.int-x3.letsencrypt.org/' ] },
  serialNumber: '03C86BD64A4E4BF82AB51386D6AA6AE11253' }
```

### chenged

```js
{ subject: { CN: 'kazu69.xyz' },
  issuer:
   { C: 'US',
     O: 'Let\'s Encrypt',
     CN: 'Let\'s Encrypt Authority X3' },
  subjectaltname: [ 'kazu69.xyz', ' www.kazu69.xyz' ],
  valid_from: 'Jul 13 23:42:00 2017 GMT',
  valid_to: 'Oct 11 23:42:00 2017 GMT',
  infoAccess:
   { 'OCSP - URI': [ 'http://ocsp.int-x3.letsencrypt.org' ],
     'CA Issuers - URI': [ 'http://cert.int-x3.letsencrypt.org/' ] },
  serialNumber: '03C86BD64A4E4BF82AB51386D6AA6AE11253' }
```

with version up `v0.0.10`